### PR TITLE
Handle 401, 403 responses more cleanly

### DIFF
--- a/confluence_export/client.py
+++ b/confluence_export/client.py
@@ -67,6 +67,16 @@ class ConfluenceClient:
             }
         )
 
+    @staticmethod
+    def _safe_response_json(response: requests.Response) -> Optional[Dict[str, Any]]:
+        """Parse JSON from a response body, returning None if the body is empty or not JSON."""
+        if not response.text:
+            return None
+        try:
+            return response.json()
+        except ValueError:
+            return None
+
     def _make_request(
         self,
         method: str,
@@ -122,16 +132,25 @@ class ConfluenceClient:
 
                 # Raise for other error status codes
                 if response.status_code >= 400:
-                    error_msg = f"API request failed with status {response.status_code}"
-                    try:
-                        error_data = response.json()
-                        if "message" in error_data:
-                            error_msg = f"{error_msg}: {error_data['message']}"
-                    except ValueError:
-                        pass
-                    raise ConfluenceAPIError(
-                        error_msg, response.status_code, response.json() if response.text else None
-                    )
+                    error_data = self._safe_response_json(response)
+
+                    if response.status_code == 401:
+                        error_msg = (
+                            "Authentication failed (401 Unauthorized). "
+                            "Check your CONFLUENCE_EMAIL and CONFLUENCE_API_TOKEN."
+                        )
+                    elif response.status_code == 403:
+                        error_msg = (
+                            "Access denied (403 Forbidden). "
+                            "Your account may not have permission to access this resource."
+                        )
+                    else:
+                        error_msg = f"API request failed with status {response.status_code}"
+
+                    if error_data and "message" in error_data:
+                        error_msg = f"{error_msg}: {error_data['message']}"
+
+                    raise ConfluenceAPIError(error_msg, response.status_code, error_data)
 
                 return response
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -173,6 +173,55 @@ class TestConfluenceClientRequests:
         assert exc_info.value.status_code == 404
 
     @responses.activate
+    def test_authentication_error_with_html_body(self):
+        """Test that 401 HTML responses produce a clear authentication error."""
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/wiki/api/v2/pages/12345",
+            body="<!doctype html><title>HTTP Status 401 - Unauthorized</title>",
+            status=401,
+            content_type="text/html",
+        )
+
+        client = ConfluenceClient(
+            base_url="https://example.atlassian.net",
+            email="test@example.com",
+            api_token="test-token",
+        )
+
+        with pytest.raises(ConfluenceAPIError) as exc_info:
+            client.get_page("12345")
+
+        assert exc_info.value.status_code == 401
+        assert "Authentication failed" in str(exc_info.value)
+        assert "CONFLUENCE_EMAIL" in str(exc_info.value)
+        assert "Expecting value" not in str(exc_info.value)
+
+    @responses.activate
+    def test_forbidden_error_with_html_body(self):
+        """Test that 403 HTML responses produce a clear permission error."""
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/wiki/api/v2/pages/12345",
+            body="<!doctype html><title>HTTP Status 403 - Forbidden</title>",
+            status=403,
+            content_type="text/html",
+        )
+
+        client = ConfluenceClient(
+            base_url="https://example.atlassian.net",
+            email="test@example.com",
+            api_token="test-token",
+        )
+
+        with pytest.raises(ConfluenceAPIError) as exc_info:
+            client.get_page("12345")
+
+        assert exc_info.value.status_code == 403
+        assert "Access denied" in str(exc_info.value)
+        assert "Expecting value" not in str(exc_info.value)
+
+    @responses.activate
     def test_rate_limiting_retry(self):
         """Test that rate limiting triggers retry."""
         # First request returns 429


### PR DESCRIPTION
## Description

Agent-generated error handling to provide clearly user explanation for HTTP 401 & 403 errors.

## Type of Change

- [ x ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Test update

## Related Issues

Fixes #9 

## Changes Made

- updated client.py to handle non-JSON response and error more intelligently on 401, 403
- add pytest case for 401 and 403

## Testing

<!-- Describe how you tested your changes -->

- [ x ] I have run `pytest` and all tests pass (agent did)
- [ x ] I have added tests that prove my fix/feature works (agent did)
- [ x ] I have tested this manually

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have run `ruff check .` and `ruff format .`
- [ ] I have updated documentation as needed
- [ x ] My changes generate no new warnings
- [ ] Any dependent changes have been merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Confluence requests when the server returns empty, HTML, or otherwise non-JSON responses.
  * Authentication and permission errors now show clearer, status-specific messages.
  * Error details are included when available, without exposing JSON parsing noise.
  * Added coverage for 401 and 403 failure cases to ensure user-facing errors remain readable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->